### PR TITLE
Track Candidate Count and Tests

### DIFF
--- a/anchor/programs/voting/src/lib.rs
+++ b/anchor/programs/voting/src/lib.rs
@@ -30,6 +30,8 @@ pub mod voting {
         let candidate = &mut ctx.accounts.candidate;
         candidate.candidate_name = candidate_name;
         candidate.candidate_votes = 0;
+        let poll =&mut ctx.accounts.poll;
+        poll.candidate_count+=1;
         Ok(())
     }
 
@@ -85,7 +87,7 @@ pub struct InitializeCandidate<'info> {
       payer = signer,
       space = 8 + Candidate::INIT_SPACE,
       seeds = [poll_id.to_le_bytes().as_ref(), candidate_name.as_ref()],
-      bump
+      bump,
     )]
     pub candidate: Account<'info, Candidate>,
     pub system_program: Program<'info, System>,
@@ -124,4 +126,5 @@ pub struct Poll {
     pub poll_start: u64,
     pub poll_end: u64,
     pub candidate_amount: u64,
+    pub candidate_count: u64,
 }

--- a/anchor/target/idl/voting.json
+++ b/anchor/target/idl/voting.json
@@ -254,6 +254,10 @@
           {
             "name": "candidate_amount",
             "type": "u64"
+          },
+          {
+            "name": "candidate_count",
+            "type": "u64"
           }
         ]
       }

--- a/anchor/target/types/voting.ts
+++ b/anchor/target/types/voting.ts
@@ -260,6 +260,10 @@ export type Voting = {
           {
             "name": "candidateAmount",
             "type": "u64"
+          },
+          {
+            "name": "candidateCount",
+            "type": "u64"
           }
         ]
       }

--- a/anchor/tests/voting.spec.ts
+++ b/anchor/tests/voting.spec.ts
@@ -69,6 +69,13 @@ describe("Voting", () => {
     console.log(blueCandidate);
     expect(blueCandidate.candidateVotes.toNumber()).toBe(0);
     expect(blueCandidate.candidateName).toBe("Blue");
+
+    const [pollAddress]= PublicKey.findProgramAddressSync(
+      [new anchor.BN(1).toArrayLike(Buffer, "le", 8)],
+      votingProgram.programId,
+    );
+    const poll= await votingProgram.account.poll.fetch(pollAddress);
+    expect(poll.candidateCount.toNumber()).toBe(2);
   });
 
   it("vote candidates", async () => {


### PR DESCRIPTION
#1 Issue Fix:
Now, Tracking candidate count on the poll account fn.
Each candidate is initialized, poll's candidate count is incremented
Added tests to verify it is increasing correctly.

Email: social.tarang@gmail.com. 
 This pull request was created for https://app.gib.work/bounties/9acd2a97-529d-4840-925e-25c982a0b0b6 in an attempt to solve a bounty #1 . Payment for the bounty is immediately sent to the contributor after merge.